### PR TITLE
Fix tasks order in right side bar

### DIFF
--- a/src/components/TaskSection.tsx
+++ b/src/components/TaskSection.tsx
@@ -78,7 +78,10 @@ const TaskSection: React.FC<ITaskSectionProps> = (props) => {
   }, [props.groupBy, tasks]);
 
   const openTaskGroups = React.useCallback(() => {
-    tasks.forEach((task) => {
+    const tasksCopy = [...tasks];
+    tasksCopy.reverse();
+
+    tasksCopy.forEach((task) => {
       openTask(task, {
         openInRightSidebar: true,
       });


### PR DESCRIPTION
Hello! I'm a user of your plugin, but it was annoying me that when we clicked on the button to add the tasks in the right side bar they won't respect the filter order.

Investigating, my guess is that every time you add a new node to the right sidebar it goes to the top, so the first item becomes the last one, when all are added. I tried to look at logseq API and seems there is no config to change this behaviour, so the only think I could think of doing is to reverse the tasks array so when inserting the items in the right side bar they end up in the correct order set in the filter.