### PR TITLE
Add an option to use the current theme colors

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -61,6 +61,13 @@ const settings: SettingSchemaDesc[] = [
     default: false,
   },
   {
+    key: 'useDefaultColors',
+    type: 'boolean',
+    title: 'Use Default Colors',
+    description: 'Use the colors from your current Logseq theme',
+    default: false,
+  },
+  {
     key: 'sectionTitleColor',
     type: 'string',
     title: 'Section Title Color',

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -13,6 +13,7 @@ interface IPluginSettings {
   lightSecondaryBackgroundColor: string;
   darkPrimaryBackgroundColor: string;
   darkSecondaryBackgroundColor: string;
+  useDefaultColors: boolean;
   sectionTitleColor: string;
   openInRightSidebar: boolean;
   whereToPlaceNewTask: string;

--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -11,9 +11,9 @@ export const themeModeState = selector({
 });
 
 const getStyleVariable = (variableName: string) => {
-  const rootElement = document.querySelector(":root");
-  if (rootElement) {
-    return getComputedStyle(rootElement).getPropertyValue(variableName);
+  const bodyElement = window.parent.document.body;
+  if (bodyElement) {
+    return getComputedStyle(bodyElement).getPropertyValue(variableName);
   } else {
     return null;
   }

--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -10,13 +10,39 @@ export const themeModeState = selector({
   }
 });
 
+const getStyleVariable = (variableName: string) => {
+  const rootElement = document.querySelector(":root");
+  if (rootElement) {
+    return getComputedStyle(rootElement).getPropertyValue(variableName);
+  } else {
+    return null;
+  }
+}
+
+export const themeColorsState = selector({
+  key: 'themeColors',
+  get: () => {
+    const themeColors = {
+      primaryBackgroundColor: getStyleVariable('--ls-primary-background-color'),
+      secondaryBackgroundColor: getStyleVariable('--ls-secondary-background-color'),
+      sectionTitleColor: getStyleVariable('--ls-link-text-color'),
+    }
+
+    if (Object.values(themeColors).some((value) => value === null)) return null
+    return themeColors
+  }
+});
+
 export const themeStyleState = selector({
   key: 'themeStyle',
   get: ({ get }) => {
     const settings = get(settingsState);
     const themeMode = get(themeModeState);
+    const themeColors = get(themeColorsState);
 
     const isLightMode = themeMode === 'light';
+
+    if (settings.useDefaultColors && themeColors) return themeColors;
 
     const primaryBackgroundColor = isLightMode
       ? settings.lightPrimaryBackgroundColor


### PR DESCRIPTION
## User story
As a **user** who has everthing configured to my liking, I want the plugins I install to **use the colors/theme I already configured**.

## Changes
- Add an option for 'use default colors'
- Get default colors from interface
- If option is selected set `primaryBackgroundColor`, `secondaryBackgroundColor` and `sectionTitleColor` to these colors instead

## Potential issue
As noted in issue [logseq/logseq#8896](https://github.com/logseq/logseq/issues/8896), there might be an issue with getting the colors from the interface when using the plugin as installed from the store, since it is in an iframe. `"effect": true` seems to be already present in the [`manifest.json`](https://github.com/logseq/marketplace/blob/master/packages/logseq-todo-plugin/manifest.json) so maybe it'll be fine.