### PR TITLE
Optionally do not treat journal entries as scheduled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ function App() {
   };
 
   const customMarkers = settings.customMarkers.split(',');
+  const treatJournalEntriesAsScheduled = settings.treatJournalEntriesAsScheduled;
 
   return (
     <main
@@ -99,7 +100,12 @@ function App() {
             <div>
               <TaskSection
                 title="Today"
-                query={getTodayTaskQuery(customMarkers)}
+                query={
+                  getTodayTaskQuery(
+                    customMarkers,
+                    treatJournalEntriesAsScheduled,
+                  )
+                }
               />
               {settings.showNextNDaysTask && (
                 <TaskSection
@@ -112,14 +118,20 @@ function App() {
                 query={
                   settings.showNextNDaysTask
                     ? getScheduledTaskQuery(
+                        treatJournalEntriesAsScheduled,
                         dayjs().add(settings.numberOfNextNDays, 'd'),
                       )
-                    : getScheduledTaskQuery()
+                    : getScheduledTaskQuery(treatJournalEntriesAsScheduled)
                 }
               />
               <TaskSection
                 title="Anytime"
-                query={getAnytimeTaskQuery(customMarkers)}
+                query={
+                  getAnytimeTaskQuery(
+                    customMarkers,
+                    treatJournalEntriesAsScheduled,
+                  )
+                }
                 groupBy={GroupBy.Page}
               />
             </div>

--- a/src/querys/anytime.ts
+++ b/src/querys/anytime.ts
@@ -1,5 +1,12 @@
-export default function getAnytimeTaskQuery(customMarkers: string[] = []) {
+export default function getAnytimeTaskQuery(
+  customMarkers: string[] = [],
+  treatJournalEntriesAsScheduled = true,
+) {
   const markers = customMarkers.map((m) => '"' + m + '"').join(' ');
+  const excludeJournalEntries = treatJournalEntriesAsScheduled ? `
+   (not [?p :block/journal? true])
+   (not [?p :block/journalDay])
+  ` : '';
   const cond =
     customMarkers.length > 0
       ? `
@@ -7,21 +14,20 @@ export default function getAnytimeTaskQuery(customMarkers: string[] = []) {
      (and
       [(contains? #{"NOW" "LATER" "TODO" "DOING"} ?marker)]
       [?b :block/page ?p]
-      (not [?p :block/journal? true])
-      (not [?p :block/journalDay])
+      ${excludeJournalEntries}
       (not [?b :block/scheduled])
       (not [?b :block/deadline]))
      (and
       [(contains? #{${markers}} ?marker)]
         [?b :block/page ?p]
+        ${excludeJournalEntries}
         (not [?b :block/scheduled])
         (not [?b :block/deadline])))
   `
       : `
     [(contains? #{"NOW" "LATER" "TODO" "DOING"} ?marker)]
     [?b :block/page ?p]
-    (not [?p :block/journal? true])
-    (not [?p :block/journalDay])
+    ${excludeJournalEntries}
     (not [?b :block/scheduled])
     (not [?b :block/deadline])
   `;

--- a/src/querys/scheduled.ts
+++ b/src/querys/scheduled.ts
@@ -1,9 +1,16 @@
 import dayjs, { Dayjs } from 'dayjs';
 
 export default function getScheduledTaskQuery(
+  treatJournalEntriesAsScheduled = true,
   startDate: Dayjs | Date = new Date(),
 ) {
   const start = dayjs(startDate).format('YYYYMMDD');
+
+  const journalEntryCond = treatJournalEntriesAsScheduled ? `
+  (and
+         [?p :block/journal? true]
+         [?p :block/journal-day ?d])` : '';
+
   const query = `
     [:find (pull ?b [*])
      :where
@@ -14,9 +21,7 @@ export default function getScheduledTaskQuery(
        (or
          [?b :block/scheduled ?d]
          [?b :block/deadline ?d])
-       (and
-         [?p :block/journal? true]
-         [?p :block/journal-day ?d]))
+       ${journalEntryCond})
      [(> ?d ${start})]]
   `;
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -54,6 +54,13 @@ const settings: SettingSchemaDesc[] = [
     default: 14,
   },
   {
+    key: 'treatJournalEntriesAsScheduled',
+    type: 'boolean',
+    title: 'Treat journal entries as scheduled',
+    description: 'Treat entries an a journal page as scheduled on that day',
+    default: true,
+  },
+  {
     key: 'openInRightSidebar',
     type: 'boolean',
     title: 'Open Task in Right Sidebar',

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -17,6 +17,7 @@ interface IPluginSettings {
   sectionTitleColor: string;
   openInRightSidebar: boolean;
   whereToPlaceNewTask: string;
+  treatJournalEntriesAsScheduled: boolean;
 }
 
 const settingsChangedEffect: AtomEffect<IPluginSettings> = ({ setSelf }) => {


### PR DESCRIPTION
This PR addresses #84. It adds the option to treat entries on journal pages as scheduled on this day – or not. The default is `true`, which preserves the previous behaviour.

Affected queries are for ‘today,’ ‘scheduled’, and ‘anytime’. The ‘next N days’ query seems to ignore entries on journal pages anyway. Since I cannot tell if this is a mistake that should be fixed, I did not touch this query.

Feedback is welcome.